### PR TITLE
fix: create a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
noticed that there are .DS_Store files committed and a hidden, proprietary macOS file created by the Finder to store custom attributes and metadata for its containing folder, such as icon positions, folder view settings, and background images. This will prevent these from being committed in the future.